### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,8 +13,8 @@ SHT21	KEYWORD1
 #######################################
 
 begin	KEYWORD2
-getHumidity  KEYWORD2
-getTemperature   KEYWORD2	
+getHumidity	KEYWORD2
+getTemperature	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords